### PR TITLE
Remove deprecated members from upsert account, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,7 @@ $call = $client->addUsersToAccount([
 
 #### Remove user(s) from an account
 
-Please note that journy.io makes a difference between removing and deleting:
-
-- Removing: when removing a user, the user will still be stored but marked as "removed".
-- Deleting: when deleting an user, the user will not be stored anymore.
+When removing a user, the user will still be stored in journy.io, but marked as "removed".
 
 ```php
 $call = $client->removeUsersFromAccount([

--- a/README.md
+++ b/README.md
@@ -145,12 +145,6 @@ $call = $client->upsertAccount([
         "array_of_values" => ["value1", "value2"],
         "this_property_will_be_deleted" => null,
     ],
-
-    // optional
-    "members" => [
-        ["userId" => "1"], // Unique identifier for the user in your database
-        ["userId" => "2"]
-    ],
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $call = $client->addUsersToAccount([
     "account" => [
         "accountId" => "accountId",
         "domain" => "acme-inc.com",
-        ],
+    ],
     "users" => [
         ["userId" => "1"], // Unique identifier for the user in your database
         ["userId" => "2"]
@@ -172,7 +172,7 @@ $call = $client->removeUsersFromAccount([
     "account" => [
         "accountId" => "accountId",
         "domain" => "acme-inc.com",
-        ],
+    ],
     "users" => [
         ["userId" => "1"], // Unique identifier for the user in your database
         ["userId" => "2"]

--- a/src/Client.php
+++ b/src/Client.php
@@ -510,22 +510,6 @@ final class Client
             $payload["properties"] = $this->formatProperties($account["properties"]);
         }
 
-        if (isset($account["members"]) && is_array($account["members"])) {
-            $payload["members"] = array_map(
-                function (array $user) {
-                    return [
-                        "identification" => $this->userIdentifiersToArray(
-                            new UserIdentified(
-                                isset($user["userId"]) ? (string) $user["userId"] : null,
-                                isset($user["email"]) ? (string) $user["email"] : null
-                            )
-                        ),
-                    ];
-                },
-                array_values($account["members"])
-            );
-        }
-
         $body = $this->streamFactory->createStream(json_encode($payload));
 
         $response = $this->http->sendRequest(

--- a/src/Client.php
+++ b/src/Client.php
@@ -556,6 +556,13 @@ final class Client
 
     public function addUsersToAccount(array $arguments): CallResult
     {
+        if (!isset($arguments["account"])) {
+            throw new InvalidArgumentException("Account can not be empty!");
+        }
+        if (!isset($arguments["users"])) {
+            throw new InvalidArgumentException("Users can not be empty!");
+        }
+
         $payload = [
             "account" => $this->accountIdentifiersToArray(
                 new AccountIdentified(
@@ -622,6 +629,13 @@ final class Client
 
     public function removeUsersFromAccount(array $arguments): CallResult
     {
+        if (!isset($arguments["account"])) {
+            throw new InvalidArgumentException("Account can not be empty!");
+        }
+        if (!isset($arguments["users"])) {
+            throw new InvalidArgumentException("Users can not be empty!");
+        }
+
         $payload = [
             "account" => $this->accountIdentifiersToArray(
                 new AccountIdentified(

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -242,10 +242,6 @@ class ClientTest extends TestCase
                         "number" => 22,
                         "date" => $now,
                     ],
-                    "members" => [
-                        ["userId" => "1"],
-                        ["userId" => "2"],
-                    ],
                 ]
             )
         );
@@ -267,14 +263,6 @@ class ClientTest extends TestCase
                         "boolean" => true,
                         "number" => 22,
                         "date" => $now->format(DATE_ATOM),
-                    ],
-                    "members" => [
-                        [
-                            "identification" => ["userId" => "1"],
-                        ],
-                        [
-                            "identification" => ["userId" => "2"],
-                        ],
                     ],
                 ],
                 $payload
@@ -301,10 +289,6 @@ class ClientTest extends TestCase
                         "number" => 22,
                         "date" => $now,
                     ],
-                    "members" => [
-                        ["userId" => "1"],
-                        ["userId" => "2"],
-                    ],
                 ]
             )
         );
@@ -325,14 +309,6 @@ class ClientTest extends TestCase
                         "boolean" => true,
                         "number" => 22,
                         "date" => $now->format(DATE_ATOM),
-                    ],
-                    "members" => [
-                        [
-                            "identification" => ["userId" => "1"],
-                        ],
-                        [
-                            "identification" => ["userId" => "2"],
-                        ],
                     ],
                 ],
                 $payload
@@ -439,10 +415,6 @@ class ClientTest extends TestCase
             $client->upsertAccount(
                 [
                     "accountId" => "1",
-                    "members" => [
-                        1 => ["userId" => "1"],
-                        2 => ["userId" => "2"],
-                    ],
                 ]
             )
         );
@@ -457,14 +429,6 @@ class ClientTest extends TestCase
                 [
                     "identification" => [
                         "accountId" => "1",
-                    ],
-                    "members" => [
-                        [
-                            "identification" => ["userId" => "1"],
-                        ],
-                        [
-                            "identification" => ["userId" => "2"],
-                        ],
                     ],
                 ],
                 $payload


### PR DESCRIPTION
In the future, the `members` argument will not longer be supported by the API. Therefore the SDK's should be updated accordingly. Please consider using `addUsersToAccount` and `removeUsersFromAccount`.